### PR TITLE
Put Venv in Bat File

### DIFF
--- a/venv.bat
+++ b/venv.bat
@@ -1,0 +1,4 @@
+python -m venv venv
+venv\Scripts\activate
+python -m pip install --upgrade pip
+pip install -r requirements.txt


### PR DESCRIPTION
This allows us to easily set up a dev environment without copy and pasting any code. 

Simply run `venv.bat` to start your venv.